### PR TITLE
[채팅 API 보완]

### DIFF
--- a/silkroad/silkroad_front/src/api/chat.ts
+++ b/silkroad/silkroad_front/src/api/chat.ts
@@ -39,3 +39,8 @@ export const fetchBuyChats = async () => {
   const response = await instance.get(`/chats/rooms/buy`)
   return response.data.data;
 }
+
+export const markAsComplete = async (roomId: number) => {
+  const response = await instance.patch(`/chats/room/${roomId}/complete`);
+  return response.data;
+};

--- a/silkroad/silkroad_front/src/navigation/MainStackNavigator.tsx
+++ b/silkroad/silkroad_front/src/navigation/MainStackNavigator.tsx
@@ -5,12 +5,14 @@ import HomeScreen from '@/src/screens/main/HomeScreen';
 import ProductDetailScreen from '@/src/screens/main/ProductDetailScreen';
 import ProductRegisterScreen from '@/src/screens/main/ProductRegisterScreen';
 import ChatDetailScreen from '../screens/chat/ChatDetailScreen';
+import ChatListScreen from '../screens/chat/ChatListScreen';
 
 export type MainStackParamList = {
   Home: undefined;
   ProductDetail: { id: string };
   ProductRegister: undefined;
   ChatDetail: {productId: number};
+  ChatList: undefined;
 };
 
 const Stack = createNativeStackNavigator<MainStackParamList>();
@@ -22,6 +24,7 @@ export default function MainStackNavigator() {
       <Stack.Screen name="ProductDetail" component={ProductDetailScreen} />
       <Stack.Screen name="ProductRegister" component={ProductRegisterScreen} />
       <Stack.Screen name="ChatDetail" component={ChatDetailScreen} />
+      <Stack.Screen name="ChatList" component={ChatListScreen} />
     </Stack.Navigator>
   );
 }

--- a/silkroad/silkroad_front/src/screens/chat/ChatDetailScreen.tsx
+++ b/silkroad/silkroad_front/src/screens/chat/ChatDetailScreen.tsx
@@ -6,7 +6,6 @@ import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { createChatRoom, getChatRoomDetail, getChatMessages, sendChatMessage} from '@/src/api/chat';
 import {formatDateLabel, formatTime} from '../../utils/date';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 export default function ChatDetailScreen() {
   const navigation = useNavigation();
   const route = useRoute();
@@ -54,9 +53,6 @@ export default function ChatDetailScreen() {
       await sendChatMessage(roomId, message);
       
       setMessage('');
-
-      const token = await AsyncStorage.getItem('accessToken');
-      console.log('🛡️ ChatMessages에서 사용하는 토큰:', token);
 
       const msgList = await getChatMessages(roomId);
       setMessages(msgList);

--- a/silkroad/silkroad_front/src/screens/chat/ChatDetailScreen.tsx
+++ b/silkroad/silkroad_front/src/screens/chat/ChatDetailScreen.tsx
@@ -1,22 +1,26 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 import {
-  View, Text, StyleSheet, TouchableOpacity, Image, ScrollView, TextInput,
+  View, Text, StyleSheet, TouchableOpacity, Image, ScrollView, TextInput, Alert,
+  KeyboardAvoidingView,
+  TouchableWithoutFeedback,
+  Keyboard,
+  Platform
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useRoute } from '@react-navigation/native';
-import { createChatRoom, getChatRoomDetail, getChatMessages, sendChatMessage} from '@/src/api/chat';
-import {formatDateLabel, formatTime} from '../../utils/date';
+import { createChatRoom, getChatRoomDetail, getChatMessages, sendChatMessage, markAsComplete } from '@/src/api/chat';
+import { formatDateLabel, formatTime } from '../../utils/date';
+
 export default function ChatDetailScreen() {
   const navigation = useNavigation();
   const route = useRoute();
-  const { productId, roomId: initialRoomId } = route.params as {productId?: number; roomId?: number};
-  
+  const { productId, roomId: initialRoomId } = route.params as { productId?: number; roomId?: number };
+
   const [roomId, setRoomId] = useState<number | null>(initialRoomId ?? null);
   const [chatRoom, setChatRoom] = useState<any>(null);
   const [messages, setMessages] = useState<any[]>([]);
   const [message, setMessage] = useState('');
-
- 
+  const [showOptions, setShowOptions] = useState(false);
 
   useEffect(() => {
     const init = async () => {
@@ -24,14 +28,23 @@ export default function ChatDetailScreen() {
         let resolvedRoomId = initialRoomId;
         if (!resolvedRoomId && productId) {
           resolvedRoomId = await createChatRoom(productId);
-          if(resolvedRoomId !== undefined) {
+          if (resolvedRoomId !== undefined) {
             setRoomId(resolvedRoomId);
           }
         }
 
         if (resolvedRoomId) {
+
           const roomDetail = await getChatRoomDetail(resolvedRoomId);
           setChatRoom(roomDetail);
+
+          if(roomDetail.sold) {
+            Alert.alert(
+              '알림',
+              '이미 판매 완료된 상품입니다.',
+              [{text: '확인', onPress: () => navigation.goBack() }]
+            )
+          }
 
           const msgList = await getChatMessages(resolvedRoomId);
           setMessages(msgList);
@@ -43,17 +56,13 @@ export default function ChatDetailScreen() {
     init();
   }, [productId, initialRoomId]);
 
-  // 메시지 전송
+  const isSeller = chatRoom?.seller;
+
   const handleSendMessage = async () => {
     if (!roomId || !message.trim()) return;
     try {
-
-      
-
       await sendChatMessage(roomId, message);
-      
       setMessage('');
-
       const msgList = await getChatMessages(roomId);
       setMessages(msgList);
     } catch (err) {
@@ -61,95 +70,165 @@ export default function ChatDetailScreen() {
     }
   };
 
-  
+  const handleMarkAsComplete = async () => {
+    Alert.alert(
+      '판매 완료 처리',
+      '정말로 이 상품을 판매 완료 처리하시겠습니까?',
+      [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '확인',
+          style: 'destructive',
+          onPress: async () => {
+            if (!roomId) return;
+            try {
+              await markAsComplete(roomId);
+              await sendChatMessage(roomId, '판매가 완료되었습니다.');
+              const updatedMessages = await getChatMessages(roomId);
+              setMessages(updatedMessages);
+              const updatedRoom = await getChatRoomDetail(roomId); // 최신 상태 조회
+              if (updatedRoom.sold) {
+                Alert.alert(
+                  '알림',
+                  '이미 판매 완료된 상품입니다.',
+                  [{ text: '확인', onPress: () => navigation.goBack() }]
+                );
+              }
+            } catch (err) {
+              console.log('판매 완료 처리 실패:', err);
+            }
+          },
+        },
+      ]
+    );
+  };
 
   return (
-    <View style={styles.container}>
-      {/* 헤더 */}
-      <View style={styles.header}>
-        <TouchableOpacity onPress={() => navigation.goBack()}>
-          <Ionicons name="chevron-back" size={24} color="#222" />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>{chatRoom?.opponentName}</Text>
-        <View style={{ width: 24 }} />
-      </View>
+      <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 90 : 0}
+    >
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+        <View style={styles.container}>
+          {/* 헤더 */}
+          <View style={styles.header}>
+            <TouchableOpacity onPress={() => navigation.goBack()}>
+              <Ionicons name="chevron-back" size={24} color="#222" />
+            </TouchableOpacity>
+            <Text style={styles.headerTitle}>{chatRoom?.opponentName}</Text>
+            <View style={{ width: 24 }} />
+          </View>
 
-      {/* 상품 정보 */}
-      <View style={styles.productInfoWrapper}>
-        <View style={styles.productInfo}>
-          <Image
-            source={{uri: chatRoom?.productImageUrl}}
-            style={styles.productImage}
-          />
+          {/* 상품 요약 정보 */}
+          <View style={styles.productInfoWrapper}>
+            <View style={styles.productInfo}>
+              <Image source={{ uri: chatRoom?.productImageUrl }} style={styles.productImage} />
+              <View>
+                <Text style={styles.productTitle}>{chatRoom?.productTitle}</Text>
+                <Text style={styles.productPrice}>
+                  {chatRoom?.productPrice.toLocaleString()}원
+                </Text>
+              </View>
+            </View>
+          </View>
+
+          {/* 채팅 메시지 리스트 */}
+          <ScrollView contentContainerStyle={styles.chatWrapper}>
+            {messages.length > 0 &&
+              (() => {
+                let lastDate = '';
+                return messages.map((msg, index) => {
+                  const currentDate = formatDateLabel(msg.sentAt);
+                  const showDate = currentDate !== lastDate;
+                  lastDate = currentDate;
+
+                  return (
+                    <View key={index}>
+                      {showDate && (
+                        <View style={styles.dateWrapper}>
+                          <Text style={styles.dateText}>{currentDate}</Text>
+                        </View>
+                      )}
+                      {msg.me ? (
+                        <View style={styles.myMessageWrapper}>
+                          <Text style={styles.time}>{formatTime(msg.sentAt)}</Text>
+                          <View style={styles.myMessage}>
+                            <Text style={styles.myMessageText}>{msg.message}</Text>
+                          </View>
+                        </View>
+                      ) : (
+                        <View style={styles.otherMessageWrapper}>
+                          <Image
+                            source={{ uri: msg.senderProfileImage }}
+                            style={styles.avatar}
+                          />
+                          <View style={styles.bubbleWithTime}>
+                            <View style={styles.otherMessage}>
+                              <Text style={styles.otherMessageText}>{msg.message}</Text>
+                            </View>
+                            <Text style={styles.timeLeft}>{formatTime(msg.sentAt)}</Text>
+                          </View>
+                        </View>
+                      )}
+                    </View>
+                  );
+                });
+              })()}
+          </ScrollView>
+
+          {/* 입력창 + 옵션 버튼 */}
           <View>
-            <Text style={styles.productTitle}>{chatRoom?.productTitle}</Text>
-            <Text style={styles.productPrice}>{chatRoom?.productPrice.toLocaleString()}원</Text>
+            <View style={styles.inputWrapper}>
+              <TouchableOpacity
+                onPress={() => setShowOptions(!showOptions)}
+                style={{ marginRight: 10 }}
+              >
+                <Ionicons name={showOptions ? 'close' : 'add'} size={24} color="#625B52" />
+              </TouchableOpacity>
+              <TextInput
+                placeholder="메세지 보내기"
+                style={styles.input}
+                value={message}
+                onChangeText={setMessage}
+              />
+              <TouchableOpacity style={styles.sendButton} onPress={handleSendMessage}>
+                <Ionicons name="send" size={20} color="#625B52" />
+              </TouchableOpacity>
+            </View>
+
+            {/* 판매자만 보이는 옵션 */}
+            {showOptions && isSeller && (
+              <View style={styles.optionsContainer}>
+                <TouchableOpacity
+                  style={styles.optionButton}
+                  onPress={() => {
+                    Alert.alert(
+                      '판매 처리',
+                      '정말로 이 상품을 판매 완료 처리하시겠습니까?',
+                      [
+                        { text: '취소', style: 'cancel' },
+                        {
+                          text: '확인',
+                          onPress: handleMarkAsComplete,
+                        },
+                      ]
+                    );
+                  }}
+                >
+                  <Text style={styles.optionText}>판매 처리</Text>
+                </TouchableOpacity>
+              </View>
+            )}
           </View>
         </View>
-      </View>
-
-      
-      {/* 채팅 목록 */}
-      <ScrollView contentContainerStyle={styles.chatWrapper}>
-        {messages.length > 0 && (() => {
-          let lastDate = '';
-          return messages.map((msg, index) => {
-            const currentDate = formatDateLabel(msg.sentAt); // ex: '2025년 8월 14일 목요일'
-            const showDate = currentDate !== lastDate;
-            lastDate = currentDate;
-
-            return (
-              <View key={index}>
-                {showDate && (
-                  <View style={styles.dateWrapper}>
-                    <Text style={styles.dateText}>{currentDate}</Text>
-                  </View>
-                )}
-                {msg.me ? (
-                  <View style={styles.myMessageWrapper}>
-                    <Text style={styles.time}>{formatTime(msg.sentAt)}</Text>
-                    <View style={styles.myMessage}>
-                      <Text style={styles.myMessageText}>{msg.message}</Text>
-                    </View>
-                  </View>
-                ) : (
-                  <View style={styles.otherMessageWrapper}>
-                    <Image source={{ uri: msg.senderProfileImage }} style={styles.avatar} />
-                    <View style={styles.bubbleWithTime}>
-                      <View style={styles.otherMessage}>
-                        <Text style={styles.otherMessageText}>{msg.message}</Text>
-                      </View>
-                      <Text style={styles.timeLeft}>{formatTime(msg.sentAt)}</Text>
-                    </View>
-                  </View>
-                )}
-              </View>
-            );
-          });
-        })()}
-      </ScrollView>
-
-      {/* 입력창 */}
-      <View style={styles.inputWrapper}>
-        <TextInput
-          placeholder="메세지 보내기"
-          style={styles.input}
-          value={message}
-          onChangeText={setMessage}
-        />
-        <TouchableOpacity onPress={handleSendMessage}>
-          <Ionicons name="send" size={20} color="#625B52" />
-        </TouchableOpacity>
-      </View>
-    </View>
+      </TouchableWithoutFeedback>
+    </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-  },
+  container: { flex: 1, backgroundColor: '#fff' },
   header: {
     marginTop: 70,
     flexDirection: 'row',
@@ -157,11 +236,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     alignItems: 'center',
   },
-  headerTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    color: '#222',
-  },
+  headerTitle: { fontSize: 18, fontWeight: 'bold', color: '#222' },
   productInfoWrapper: {
     marginTop: 16,
     borderTopWidth: 1,
@@ -170,96 +245,53 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     paddingHorizontal: 16,
   },
-  productInfo: {
+  productInfo: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  productImage: { width: 60, height: 60, borderRadius: 8 },
+  productTitle: { fontSize: 13, color: '#222', fontWeight: '500', marginBottom: 6 },
+  productPrice: { fontSize: 14, fontWeight: 'bold', color: '#000' },
+  optionsContainer: {
+    bottom:0,
+    left: 0,
+    right: 0,
+    backgroundColor: 'white',
+    paddingVertical: 12,
     flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
+    justifyContent: 'space-around',
+    borderTopLeftRadius: 10,
+    borderTopRightRadius: 10,
+    elevation: 5,
   },
-  productImage: {
-    width: 60,
-    height: 60,
+  optionButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    backgroundColor: '#EEE',
     borderRadius: 8,
   },
-  productTitle: {
-    fontSize: 13,
-    color: '#222',
-    fontWeight: '500',
-    marginBottom: 6,
+  optionText: {
+    fontSize: 16,
   },
-  productPrice: {
-    fontSize: 14,
-    fontWeight: 'bold',
-    color: '#000',
-  },
-  dateWrapper: {
-    alignItems: 'center',
-    marginVertical: 14,
-    marginBottom:20,
-  },
-  dateText: {
-    fontSize: 12,
-    color: '#888',
-  },
-  chatWrapper: {
-    paddingHorizontal: 16,
-    paddingBottom: 90,
-  },
-    otherMessageWrapper: {
-        flexDirection: 'row',
-        alignItems: 'flex-end',
-        marginBottom: 23,
-        gap: 8,
-    },
-    bubbleWithTime: {
-    flexDirection: 'row',
-    alignItems: 'flex-end',
-    },
-
-    timeLeft: {
-    fontSize: 11,
-    color: '#888',
-    marginLeft: 6,
+  completeButton: {
+    marginTop: 10,
+    backgroundColor: '#625B52',
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 8,
     alignSelf: 'flex-end',
-    },
-  avatar: {
-    width: 40,
-    height: 40,
-    borderRadius: 16,
   },
-  otherMessage: {
-    backgroundColor: '#eee',
-    padding: 10,
-    borderRadius: 16,
-    maxWidth: 250,
-    marginRight: 4,
-  },
-  otherMessageText: {
-    fontSize: 14,
-    color: '#222',
-  },
-  myMessageWrapper: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    alignItems: 'flex-end',
-    marginBottom: 23,
-  },
-  myMessage: {
-    backgroundColor: '#F6E4D7',
-    padding: 10,
-    borderRadius: 16,
-    maxWidth: 250,
-    marginRight: 4,
-  },
-  myMessageText: {
-    fontSize: 14,
-    color: '#222',
-  },
-  time: {
-    fontSize: 11,
-    color: '#888',
-    marginTop: 4,
-    marginHorizontal: 4,
-  },
+  completeButtonText: { color: '#fff', fontSize: 13, fontWeight: 'bold' },
+  dateWrapper: { alignItems: 'center', marginVertical: 14, marginBottom: 20 },
+  dateText: { fontSize: 12, color: '#888' },
+  chatWrapper: { paddingHorizontal: 16, paddingBottom: 90 },
+  otherMessageWrapper: { flexDirection: 'row', alignItems: 'flex-end', marginBottom: 23, gap: 8 },
+  bubbleWithTime: { flexDirection: 'row', alignItems: 'flex-end' },
+  timeLeft: { fontSize: 11, color: '#888', marginLeft: 6, alignSelf: 'flex-end' },
+  avatar: { width: 40, height: 40, borderRadius: 16 },
+  otherMessage: { backgroundColor: '#eee', padding: 10, borderRadius: 16, maxWidth: 250, marginRight: 4 },
+  otherMessageText: { fontSize: 14, color: '#222' },
+  myMessageWrapper: { flexDirection: 'row', justifyContent: 'flex-end', alignItems: 'flex-end', marginBottom: 23 },
+  myMessage: { backgroundColor: '#F6E4D7', padding: 10, borderRadius: 16, maxWidth: 250, marginRight: 4 },
+  myMessageText: { fontSize: 14, color: '#222' },
+  time: { fontSize: 11, color: '#888', marginTop: 4, marginHorizontal: 4 },
   inputWrapper: {
     flexDirection: 'row',
     paddingHorizontal: 16,
@@ -268,7 +300,6 @@ const styles = StyleSheet.create({
     borderColor: '#eee',
     alignItems: 'center',
     backgroundColor: '#fff',
-    position: 'absolute',
     bottom: 0,
     width: '100%',
   },
@@ -279,7 +310,9 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     paddingHorizontal: 14,
     paddingVertical: 8,
-    marginRight: 10,
     fontSize: 14,
   },
+  sendButton:{
+    marginLeft:5,
+  }
 });

--- a/silkroad/silkroad_front/src/screens/main/ProductDetailScreen.tsx
+++ b/silkroad/silkroad_front/src/screens/main/ProductDetailScreen.tsx
@@ -33,7 +33,6 @@ export default function ProductDetailScreen() {
         setBookmarkCount(res.data.bookmarkCount);
 
         const bookmarkRes = await fetchBookmarkStatus(id);
-        console.log("찜 여부 응답:", bookmarkRes.data);
         setIsBookmarked(bookmarkRes.data.bookmarked);
 
       } catch (err) {
@@ -87,6 +86,7 @@ export default function ProductDetailScreen() {
       <ProductChatBanner
         productId={product.id} 
         price = {product.price}
+        username = {product.sellerUsername}
         isBookmarked={isBookmarked}
         onToggleBookmark = {handleToggleBookmark}
       />

--- a/silkroad/silkroad_front/src/screens/main/ProductRegisterScreen.tsx
+++ b/silkroad/silkroad_front/src/screens/main/ProductRegisterScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View, Text, TextInput, StyleSheet, TouchableOpacity, Image, ScrollView, Alert
 } from 'react-native';
@@ -7,6 +7,7 @@ import ModalSelector from 'react-native-modal-selector';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { registerProduct } from '@/src/api/product';
+import { getMyProfile } from '@/src/api/auth';
 
 export default function ProductRegisterScreen() {
   const [title, setTitle] = useState('');
@@ -15,6 +16,13 @@ export default function ProductRegisterScreen() {
   const [description, setDescription] = useState('');
   const [images, setImages] = useState<string[]>([]);
   const navigation = useNavigation();
+
+  const [profile, setProfile] = useState<{
+        username: string;
+        name: string;
+        location: string;
+        profileImageUrl: string;
+    } | null>(null);
 
   const pickImages = async () => {
     const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
@@ -42,7 +50,11 @@ export default function ProductRegisterScreen() {
   { key: 'BEAUTY', label: '뷰티' },
   { key: 'SPORTS', label: '스포츠' },
   { key: 'ETC', label: '기타' },
+
+  
 ];
+
+
 
   const handleSubmit = async() => {
     if (!title || !price || !description || images.length === 0) {
@@ -75,13 +87,21 @@ export default function ProductRegisterScreen() {
     }
   }
 
+  useEffect(() => {
+      const fetchUser = async () => {
+        const res = await getMyProfile();
+        setProfile(res);
+      };
+      fetchUser();
+    }, []);
+
   return ( 
     <ScrollView style={styles.container}>
       <View style={styles.header}>
               <TouchableOpacity onPress={() => navigation.goBack()}>
                 <Ionicons name="chevron-back" size={24} color="#222" />
               </TouchableOpacity>
-              <Text style={styles.headerText}>윤브라보</Text>
+              <Text style={styles.headerText}>{profile?.name}</Text>
               <View style={{ width: 24 }} /> {/* 오른쪽 여백 맞추기 */}
       </View>
 

--- a/silkroad/silkroad_front/src/screens/main/components/ProductChatBanner.tsx
+++ b/silkroad/silkroad_front/src/screens/main/components/ProductChatBanner.tsx
@@ -1,11 +1,13 @@
+import React, { useEffect, useState } from 'react';
 import { MainStackParamList } from '@/src/navigation/MainStackNavigator';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import React from 'react';
+import { MyPageStackParamList } from '@/src/navigation/MyPageStackNavigator';
 import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
-
+import { getMyProfile } from '@/src/api/auth';
 interface Props {
   productId: number;
+  username: string;
   price: number;
   isBookmarked: boolean;
   onToggleBookmark: () => void;
@@ -13,22 +15,47 @@ interface Props {
 
 export default function ProductChatBanner({
   productId,
+  username,
   price,
   isBookmarked,
   onToggleBookmark
 }: Props) {
   const navigation = useNavigation<NativeStackNavigationProp<MainStackParamList>>();
-  
+  const [profile, setProfile] = useState<{
+          username: string;
+          name: string;
+          location: string;
+          profileImageUrl: string;
+      } | null>(null);
+
+  useEffect(() => {
+        const fetchUser = async () => {
+          const res = await getMyProfile();
+          setProfile(res);
+        };
+        fetchUser();
+  }, []);
+  const isMyProduct = profile?.username === username;
+
+  const handlePress = () => {
+    if (isMyProduct) {
+      navigation.navigate('ChatList');
+    } else {
+      navigation.navigate('ChatDetail', { productId });
+    }
+  };
   return (
     <View style={styles.container}>
-      <TouchableOpacity onPress={onToggleBookmark}>
-        <Text style={styles.likes}>{isBookmarked ? '♥' : '♡'}</Text>
-      </TouchableOpacity>
-      <Text style={styles.price}>{Number(price).toLocaleString()}원</Text>
-      <TouchableOpacity style={styles.button} onPress={() => {console.log('🔥 navigating to ChatDetail with productId:', productId); navigation.navigate('ChatDetail', {productId});} }>
-        <Text style={styles.buttonText}>거래 채팅하기</Text>
-      </TouchableOpacity>
-    </View>
+    <TouchableOpacity onPress={onToggleBookmark}>
+      <Text style={styles.likes}>{isBookmarked ? '♥' : '♡'}</Text>
+    </TouchableOpacity>
+    <Text style={styles.price}>{Number(price).toLocaleString()}원</Text>
+    <TouchableOpacity style={styles.button} onPress={handlePress}>
+      <Text style={styles.buttonText}>
+        {isMyProduct ? '채팅 목록 보기' : '거래 채팅하기'}
+      </Text>
+    </TouchableOpacity>
+  </View>
   );
 }
 

--- a/silkroad/silkroad_server/src/main/java/com/silkroad/silkroad/domain/product/Product.java
+++ b/silkroad/silkroad_server/src/main/java/com/silkroad/silkroad/domain/product/Product.java
@@ -43,7 +43,7 @@ public class Product {
 
     @Setter
     @Column(nullable = false)
-    private boolean isSold; // 판매 완료 여부 (true면 파냄 완료)
+    private boolean isSold; // 판매 완료 여부
 
     @Setter
     @Column(nullable = false)

--- a/silkroad/silkroad_server/src/main/java/com/silkroad/silkroad/dto/chat/ChatRoomDetailResponse.java
+++ b/silkroad/silkroad_server/src/main/java/com/silkroad/silkroad/dto/chat/ChatRoomDetailResponse.java
@@ -14,4 +14,5 @@ public class ChatRoomDetailResponse {
     private int productPrice;
     private String productImageUrl;
     private boolean isSeller;
+    private boolean isSold;
 }

--- a/silkroad/silkroad_server/src/main/java/com/silkroad/silkroad/service/ChatService.java
+++ b/silkroad/silkroad_server/src/main/java/com/silkroad/silkroad/service/ChatService.java
@@ -77,7 +77,8 @@ public class ChatService {
                 product.getTitle(),
                 product.getPrice(),
                 product.getImages().isEmpty() ? null : product.getImages().get(0).getImageUrl(),
-                room.getSeller().equals(user) // 판매 완료 처리 시 판별 위함.
+                room.getSeller().equals(user), // 판매 완료 처리 시 판별 위함.
+                product.isSold()
         );
     }
 


### PR DESCRIPTION
- 자신이 판매자인 경우 -> 중복채팅방 생성 방지 -> 분기 처리를 통해 '채팅하기' 버튼이 아닌, '채팅 목록' 조회 버튼 노출
- seller boolean 반환 값을 통해 판매자를 판별하여, 판매자만 판매 처리 진행하도록 하는 처리 API 연동
- 채팅방 상단 상세 조회 API 반환 값에 sold boolean을 포함하여 팔린 경우, 모달 창 띄운 후 채팅방 접근 X